### PR TITLE
Convert all tailwind rem values to px values

### DIFF
--- a/src/official-widgets/camera-search/camera-search.tsx
+++ b/src/official-widgets/camera-search/camera-search.tsx
@@ -158,13 +158,15 @@ const CameraSearch = memo((props: {
     multisearchWithParams(params);
   };
 
-  const onCameraButtonClick = useCallback((): void => {
+  const onCameraButtonClick = (event: any): void => {
+    event.stopPropagation();
+    event.preventDefault();
     productSearch.send(Actions.CLICK, {
       label: Labels.ENTER,
       cat: Category.ENTRANCE,
     });
     setDialogVisible(true);
-  }, []);
+  };
 
   const getScreen = (): ReactElement => {
     switch (screen) {

--- a/src/official-widgets/camera-search/icons/CameraIcon.tsx
+++ b/src/official-widgets/camera-search/icons/CameraIcon.tsx
@@ -1,7 +1,7 @@
 import type { FC, ReactElement } from 'react';
 
 interface CameraIconProps {
-  onClickHandler: () => void;
+  onClickHandler: (event: any) => void;
 }
 
 const CameraIcon: FC<CameraIconProps> = ({ onClickHandler }): ReactElement => (

--- a/src/official-widgets/camera-search/screens/ResultScreen.tsx
+++ b/src/official-widgets/camera-search/screens/ResultScreen.tsx
@@ -298,8 +298,8 @@ const ResultScreen: FC<ResultScreenProps> = ({
               </div>
 
               {searchHistory && searchHistory?.length > 1 && (
-                <div className='pt-4 text-medium'>
-                  <p className='text-primary'>Previous views</p>
+                <div className='pt-4'>
+                  <span className='calls-to-action-text text-primary'>Previous views</span>
                   <div className='no-scrollbar flex h-full flex-row gap-1 overflow-scroll pt-1' data-pw='cs-previous-views'>
                     {searchHistory
                       ?.slice(1)
@@ -352,7 +352,7 @@ const ResultScreen: FC<ResultScreenProps> = ({
                   }}>
                   {inputSuggestions.map((keyword, index) => (
                     <ListboxItem key={keyword} className={cn(keyword === search ? 'bg-gray' : '', 'pl-8')}>
-                      <span data-pw={`autocomplete-suggestion-${index + 1}`}>{keyword}</span>
+                      <span className='text-base' data-pw={`autocomplete-suggestion-${index + 1}`}>{keyword}</span>
                     </ListboxItem>
                   ))}
                 </Listbox>

--- a/src/official-widgets/camera-search/screens/ResultScreen.tsx
+++ b/src/official-widgets/camera-search/screens/ResultScreen.tsx
@@ -160,7 +160,7 @@ const ResultScreen: FC<ResultScreenProps> = ({
             onKeywordSearch(search, keyword === selectedChip ? '' : keyword);
             scrollToResultsTop();
           }}>
-          <span className='calls-to-action-text text-primary' data-pw={`cs-autocomplete-chip-${index + 1}`}>{keyword}</span>
+          <span className='calls-to-action-text leading-6 text-primary' data-pw={`cs-autocomplete-chip-${index + 1}`}>{keyword}</span>
         </Chip>
       ));
     }
@@ -289,7 +289,7 @@ const ResultScreen: FC<ResultScreenProps> = ({
                 <HotspotPreview className='w-3/5' referenceImage={getReferenceImage()}/>
 
                 <FileDropzone onImageUpload={onImageUpload} name='upload-icon'>
-                  <p className='px-3 py-2 text-medium'>
+                  <p className='px-3 py-2 text-medium leading-6'>
                     <span className='calls-to-action-text text-primary'>drag an image to</span> <br/>
                     <span className='calls-to-action-text text-primary'>search or </span>
                     <span className='calls-to-action-text text-primary underline'>click to browse</span>

--- a/src/official-widgets/camera-search/screens/UploadScreen.tsx
+++ b/src/official-widgets/camera-search/screens/UploadScreen.tsx
@@ -96,12 +96,12 @@ const UploadScreen: FC<UploadScreenProps> = ({ onModalClose, onImageUpload }) =>
                     : <UploadIcon className='size-2/5 py-5'/>
                 }
 
-                <p className='calls-to-action-text hidden px-3 py-2 text-primary md:block'>
+                <p className='calls-to-action-text hidden px-3 py-2 leading-6 text-primary md:block'>
                   drag an image to <br/>
                   search or <span className='underline'>click to browse</span>
                 </p>
 
-                <p className='calls-to-action-text pt-3 text-primary md:hidden'>
+                <p className='calls-to-action-text pt-3 leading-6 text-primary md:hidden'>
                   tap here to <br className='md:hidden'/> search an image
                 </p>
               </div>

--- a/src/official-widgets/similar-search/screens/ResultScreen.tsx
+++ b/src/official-widgets/similar-search/screens/ResultScreen.tsx
@@ -172,7 +172,7 @@ const ResultScreen: FC<ResultScreenProps> = ({
             onKeywordSearch(search, keyword === selectedChip ? '' : keyword);
             scrollToResultsTop();
           }}>
-          <span className='calls-to-action-text text-primary' data-pw={`ss-autocomplete-chip-${index + 1}`}>{keyword}</span>
+          <span className='calls-to-action-text leading-6 text-primary' data-pw={`ss-autocomplete-chip-${index + 1}`}>{keyword}</span>
         </Chip>
       ));
     }

--- a/src/official-widgets/similar-search/screens/ResultScreen.tsx
+++ b/src/official-widgets/similar-search/screens/ResultScreen.tsx
@@ -306,8 +306,8 @@ const ResultScreen: FC<ResultScreenProps> = ({
               </div>
 
               {searchHistory && searchHistory?.length > 1 && (
-                <div className='pt-2 text-medium'>
-                  <p className='text-primary'>Previous views</p>
+                <div className='pt-2'>
+                  <p className='calls-to-action-text text-primary'>Previous views</p>
                   <div className='no-scrollbar flex h-full flex-row gap-1 overflow-scroll pt-1' data-pw='ss-previous-views'>
                     {searchHistory
                       ?.slice(1)
@@ -369,7 +369,7 @@ const ResultScreen: FC<ResultScreenProps> = ({
                   }}>
                   {inputSuggestions.map((keyword, index) => (
                     <ListboxItem key={keyword} className={cn(keyword === search ? 'bg-gray' : '', 'pl-8')}>
-                      <span data-pw={`autocomplete-suggestion-${index + 1}`}>{keyword}</span>
+                      <span className='text-base' data-pw={`autocomplete-suggestion-${index + 1}`}>{keyword}</span>
                     </ListboxItem>
                   ))}
                 </Listbox>

--- a/src/official-widgets/similar-search/similar-search.tsx
+++ b/src/official-widgets/similar-search/similar-search.tsx
@@ -127,7 +127,9 @@ const SimilarSearch: FC<SimilarSearchProps> = ({ configs, productSearch, element
     multisearchWithParams(params);
   };
 
-  const onPopupIconClick = (): void => {
+  const onPopupIconClick = (event: any): void => {
+    event.stopPropagation();
+    event.preventDefault();
     productSearch.send(Actions.CLICK, {
       cat: Category.ENTRANCE,
       label: Labels.ICON,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const {nextui} = require('@nextui-org/theme');
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 const getFontObj = (configName) => {
   const deviceTypes = ['mobile', 'tablet', 'desktop'];
@@ -25,6 +26,36 @@ const getColourObj = (configName) => {
   return colourObj;
 };
 
+// Convert all rem units to px units
+function remToPx(input, fontSize = 16) {
+  if (input == null) {
+    return input;
+  }
+  switch (typeof input) {
+    case 'object':
+      if (Array.isArray(input)) {
+        return input.map((val) => remToPx(val, fontSize));
+      }
+      const ret = {};
+      for (const key in input) {
+        ret[key] = remToPx(input[key], fontSize);
+      }
+      return ret;
+    case 'string':
+      return input.replace(
+        /(\d*\.?\d+)rem$/,
+        (_, val) => `${parseFloat(val) * fontSize}px`,
+      );
+    case 'function':
+      return eval(input.toString().replace(
+        /(\d*\.?\d+)rem/g,
+        (_, val) => `${parseFloat(val) * fontSize}px`,
+      ));
+    default:
+      return input;
+  }
+}
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -32,13 +63,14 @@ module.exports = {
     './node_modules/@nextui-org/theme/dist/components/(button|card|chip|image|input|listbox|spacer|skeleton).js',
   ],
   theme: {
+    ...remToPx(defaultTheme),
     extend: {
       textColor: getColourObj('text'),
       backgroundColor: getColourObj('background'),
       fontSize: getFontObj('fontSize'),
       fontWeight: getFontObj('fontWeight'),
       height: {
-        108: '27rem',
+        108: '432px',
       },
       spacing: {
         '19/20': '95%',


### PR DESCRIPTION
Tailwind by default uses rem values for its css, this is a problem as different website html can have different font sizes which will affect the calculated rem value. 
Need to change all rem values to px values so that the styling sizes will be fixed.

Fix: Prevent default/propagation on clicking of Camera Search and Similar Search icons