### PR TITLE
[ES-10921] fix but with listbox item onAction not triggering searchCallback

### DIFF
--- a/src/official-widgets/search-bar/search-bar.tsx
+++ b/src/official-widgets/search-bar/search-bar.tsx
@@ -174,10 +174,6 @@ const SearchBar: FC<SearchBarResultProps> = ({ textQuery, imUrl }): ReactElement
                             {intl.formatMessage({ id: 'suggestions' })}
                           </p>
                           <Listbox
-                              onAction={(key) => {
-                                setQuery(String(key));
-                                emitSearchBarCallback(String(key), image);
-                              }}
                               aria-label='Autocomplete Dropdown'
                           >
                             <ListboxSection classNames={{ base: 'mb-0' }}>
@@ -193,6 +189,10 @@ const SearchBar: FC<SearchBarResultProps> = ({ textQuery, imUrl }): ReactElement
                                                                className='size-4' />
                                       )}
                                       textValue={result}
+                                      onPress={() => {
+                                        setQuery(result);
+                                        emitSearchBarCallback(result, image);
+                                      }}
                                   >
                             <span className='pl-2 text-primary'
                                   data-pw={`sb-autocomplete-suggestion-${index + 1}`}>{result}</span>
@@ -271,10 +271,6 @@ const SearchBar: FC<SearchBarResultProps> = ({ textQuery, imUrl }): ReactElement
                         {intl.formatMessage({ id: 'recentSearches' })}
                       </p>
                       <Listbox
-                          onAction={(key) => {
-                            setQuery(String(key));
-                            emitSearchBarCallback(String(key), image);
-                          }}
                           aria-label='Recent searches'
                       >
                         <ListboxSection classNames={{ base: 'mb-0' }}>
@@ -290,6 +286,12 @@ const SearchBar: FC<SearchBarResultProps> = ({ textQuery, imUrl }): ReactElement
                                                            className='size-4' />
                                   )}
                                   textValue={entry.query}
+                                  onPress={() => {
+                                    if (entry && entry.query) {
+                                      setQuery(entry.query);
+                                      emitSearchBarCallback(entry.query, image);
+                                    }
+                                }}
                               >
                             <span className='pl-2 text-primary'
                                   data-pw={`sb-recent-searches-${entry.id}`}>{entry.query}</span>


### PR DESCRIPTION
For some reason after the most recent update to the heroui packages the listbox onAction handler was not firing the searchCallback.

I moved the function call to each listbox item as an onPress.