### PR TITLE
[MC-2936] Register default config/text readers for AI Search Launcher (25) and Embedded Shopping Assistant (26)

### DIFF
--- a/customization-reader.ts
+++ b/customization-reader.ts
@@ -19,6 +19,8 @@ import { DEFAULT_CUSTOMIZATIONS as DEFAULT_CUSTOMIZATIONS_21 } from './src/offic
 import { DEFAULT_CUSTOMIZATIONS as DEFAULT_CUSTOMIZATIONS_22 } from './src/official-widgets/slide-out-drawer/default-config';
 import { DEFAULT_CUSTOMIZATIONS as DEFAULT_CUSTOMIZATIONS_23 } from './src/official-widgets/buy-the-look/default-config';
 import { DEFAULT_CUSTOMIZATIONS as DEFAULT_CUSTOMIZATIONS_24 } from './src/official-widgets/in-page-carousel-v3/default-config';
+import { DEFAULT_CUSTOMIZATIONS as DEFAULT_CUSTOMIZATIONS_25 } from './src/official-widgets/ai-search-launcher/default-config';
+import { DEFAULT_CUSTOMIZATIONS as DEFAULT_CUSTOMIZATIONS_26 } from './src/official-widgets/embedded-shopping-assistant/default-config';
 
 const configs: Record<string, WidgetConfig['customizations']> = {
   7: DEFAULT_CUSTOMIZATIONS_7,
@@ -38,6 +40,8 @@ const configs: Record<string, WidgetConfig['customizations']> = {
   22: DEFAULT_CUSTOMIZATIONS_22,
   23: DEFAULT_CUSTOMIZATIONS_23,
   24: DEFAULT_CUSTOMIZATIONS_24,
+  25: DEFAULT_CUSTOMIZATIONS_25,
+  26: DEFAULT_CUSTOMIZATIONS_26,
 };
 
 const args = process.argv.slice(2);

--- a/text-reader.ts
+++ b/text-reader.ts
@@ -19,6 +19,8 @@ import { DEFAULT_TEXTS as DEFAULT_TEXTS_21 } from './src/official-widgets/in-pag
 import { DEFAULT_TEXTS as DEFAULT_TEXTS_22 } from './src/official-widgets/slide-out-drawer/default-config';
 import { DEFAULT_TEXTS as DEFAULT_TEXTS_23 } from './src/official-widgets/buy-the-look/default-config';
 import { DEFAULT_TEXTS as DEFAULT_TEXTS_24 } from './src/official-widgets/in-page-carousel-v3/default-config';
+import { DEFAULT_TEXTS as DEFAULT_TEXTS_25 } from './src/official-widgets/ai-search-launcher/default-config';
+import { DEFAULT_TEXTS as DEFAULT_TEXTS_26 } from './src/official-widgets/embedded-shopping-assistant/default-config';
 
 const configs: Record<string, LanguagePack> = {
   7: DEFAULT_TEXTS_7,
@@ -38,6 +40,8 @@ const configs: Record<string, LanguagePack> = {
   22: DEFAULT_TEXTS_22,
   23: DEFAULT_TEXTS_23,
   24: DEFAULT_TEXTS_24,
+  25: DEFAULT_TEXTS_25,
+  26: DEFAULT_TEXTS_26,
 };
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
customization-reader.ts and text-reader.ts map context IDs to each widget's DEFAULT_CUSTOMIZATIONS/DEFAULT_TEXTS exports, and are used by the create-version-and-alias-entries release pipeline to populate default_config/default_texts on /v1/admin/widget-versions. The map was never extended past context 24 (in-page-carousel-v3), so looking up context 25 or 26 returned configs[id] === undefined, and JSON.stringify(undefined) printed the literal string "undefined" — which the pipeline then wrote straight into the DB.

This surfaced downstream in bazooka-web: opening Customize Wigmix for a placement on context 25 crashed with SyntaxError: "undefined" is not valid JSON, because default_config/default_texts for widget version 1.0.31 (config_id 957) held the literal string "undefined" instead of real JSON.

Changes

Added DEFAULT_CUSTOMIZATIONS_25/DEFAULT_TEXTS_25 imports and map entries for ai-search-launcher (context 25).
Added DEFAULT_CUSTOMIZATIONS_26/DEFAULT_TEXTS_26 imports and map entries for embedded-shopping-assistant (context 26).
No changes to the underlying default-config.ts files for either widget — both already exported fully-populated configs, they just weren't wired into the readers.